### PR TITLE
fix(README): lazy.nvim conf 'setup'->'config'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ vim.keymap.set("n", "gx", lsplinks.gx)
 ``` lua
 {
     "icholy/lsplinks.nvim",
-    setup = function()
+    config = function()
         local lsplinks = require("lsplinks")
         lsplinks.setup()
         vim.keymap.set("n", "gx", lsplinks.gx)


### PR DESCRIPTION
Hi

There is an error in your example of lazy config in README. Plugins are set up using `config` option ([source](https://github.com/folke/lazy.nvim?tab=readme-ov-file#-plugin-spec)).
